### PR TITLE
Setup a better busy_handler that respects a timeout

### DIFF
--- a/lib/enhanced_sqlite3/adapter.rb
+++ b/lib/enhanced_sqlite3/adapter.rb
@@ -34,7 +34,7 @@ module EnhancedSQLite3
 
     def configure_busy_handler_timeout
       return unless @config.key?(:timeout)
-      
+
       timeout = self.class.type_cast_config_to_integer(@config[:timeout])
       @raw_connection.busy_handler do |count|
         timed_out = false

--- a/lib/enhanced_sqlite3/adapter.rb
+++ b/lib/enhanced_sqlite3/adapter.rb
@@ -22,6 +22,7 @@ module EnhancedSQLite3
     def configure_connection
       super
 
+      configure_busy_handler_timeout
       configure_pragmas
       configure_extensions
 
@@ -30,6 +31,28 @@ module EnhancedSQLite3
     end
 
     private
+
+    def configure_busy_handler_timeout
+      return unless @config.key?(:timeout)
+      
+      timeout = self.class.type_cast_config_to_integer(@config[:timeout])
+      @raw_connection.busy_handler do |count|
+        timed_out = false
+        # capture the start time of this blocked write
+        @start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) if count == 0
+        # keep track of elapsed time every 100 iterations (to lower load)
+        if count % 100 == 0
+          @elapsed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @start_time
+          # fail if we exceed the timeout value (captured from the timeout config option, converted to seconds)
+          timed_out = @elapsed_time > timeout
+        end
+        if timed_out
+          false # this will cause the BusyException to be raised
+        else
+          sleep 0.001 # sleep 1 millisecond (or whatever)
+        end
+      end
+    end
 
     def configure_pragmas
       @config.fetch(:pragmas, []).each do |key, value|


### PR DESCRIPTION
As discussed in this PR https://github.com/rails/rails/pull/49352, the new `retries` option in Rails isn't optimal. 

1. It is difficult, if not impossible, to determine what the correct limit is
2. It can be slow in a multi-thread environment, as you will execute the Ruby `busy_handler` proc many, many, many times from within a C control frames

This provides a superior alternative which still respects a timeout, but it allows for other threads/fibers to take control while the current context is blocked on a write lock.